### PR TITLE
targetTouch in getEventClientYX can be undefined

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -680,8 +680,8 @@ export class Events {
 
   private getEventClientYX(ev, name) {
     const targetTouch = ev.type === name && ev.targetTouches && (ev.targetTouches[0] || ev.changedTouches[0]);
-    const clientY: number = ev.type === name ? targetTouch.clientY : ev.clientY;
-    const clientX: number = ev.type === name ? targetTouch.clientX : ev.clientX;
+    const clientY: number = (ev.type === name && targetTouch) ? targetTouch.clientY : ev.clientY;
+    const clientX: number = (ev.type === name && targetTouch) ? targetTouch.clientX : ev.clientX;
     const timeDiff: number = (Date.now()) - (this.steps[this.steps.length - 1]?.time || 0);
     const distanceY: number = Math.abs(clientY - (this.steps[this.steps.length - 1]?.posY || 0));
     const velocityY: number = distanceY / timeDiff;


### PR DESCRIPTION
I have a plenty sentry errors indicated that Chrome WebView users faced with issue that targetTouch is undefined. I don't know the reason and can't repeat this issue by myself.
<img width="1074" alt="Screenshot 2023-08-05 at 10 54 58" src="https://github.com/tech-systems/panes/assets/807140/10b9411b-813a-447c-8160-e2f53d20e6f2">
